### PR TITLE
Fc 144/assign roles for groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <title>${project.name} ${project.version}</title>
     
     <!-- Dependencies version -->
-    <fortress.realm.version>1.0.1</fortress.realm.version>
+    <fortress.realm.version>1.0.2-SNAPSHOT</fortress.realm.version>
     <cxf.version>3.1.6</cxf.version>
     <httpclient.version>3.1</httpclient.version>
     <java.version>1.7</java.version>

--- a/src/main/java/org/apache/directory/fortress/rest/AccessMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/AccessMgrImpl.java
@@ -23,12 +23,7 @@ import org.apache.directory.fortress.core.AccessMgr;
 import org.apache.directory.fortress.core.AccessMgrFactory;
 import org.apache.directory.fortress.core.GlobalErrIds;
 import org.apache.directory.fortress.core.SecurityException;
-import org.apache.directory.fortress.core.model.Permission;
-import org.apache.directory.fortress.core.model.Session;
-import org.apache.directory.fortress.core.model.User;
-import org.apache.directory.fortress.core.model.UserRole;
-import org.apache.directory.fortress.core.model.FortRequest;
-import org.apache.directory.fortress.core.model.FortResponse;
+import org.apache.directory.fortress.core.model.*;
 import org.apache.log4j.Logger;
 
 import java.util.List;
@@ -97,6 +92,43 @@ class AccessMgrImpl extends AbstractMgrImpl
     /* no qualifier*/ FortResponse createSessionTrusted( FortRequest request )
     {
         return createSession( request, TRUSTED );
+    }
+
+    /**
+     * Creates a group-type trusted session
+     *
+     * @param request The request We want to create a session for
+     * @return The created response
+     */
+    /* no qualifier*/ FortResponse createGroupSessionTrusted( FortRequest request )
+    {
+        return createGroupSession( request );
+    }
+
+
+    /**
+     * Creates a Group-type session
+     *
+     * @param request The request We want to create a session for
+     * @return The created response
+     */
+    private FortResponse createGroupSession( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            AccessMgr accessMgr = AccessMgrFactory.createInstance( request.getContextId() );
+            Group inGroup = (Group) request.getEntity();
+            Session outSession = accessMgr.createGroupSession( inGroup );
+            response.setSession( outSession );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, LOG, se );
+        }
+
+        return response;
     }
 
     

--- a/src/main/java/org/apache/directory/fortress/rest/AccessMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/AccessMgrImpl.java
@@ -100,19 +100,7 @@ class AccessMgrImpl extends AbstractMgrImpl
      * @param request The request We want to create a session for
      * @return The created response
      */
-    /* no qualifier*/ FortResponse createGroupSessionTrusted( FortRequest request )
-    {
-        return createGroupSession( request );
-    }
-
-
-    /**
-     * Creates a Group-type session
-     *
-     * @param request The request We want to create a session for
-     * @return The created response
-     */
-    private FortResponse createGroupSession( FortRequest request )
+    /* no qualifier*/ FortResponse createGroupSession( FortRequest request )
     {
         FortResponse response = createResponse();
 

--- a/src/main/java/org/apache/directory/fortress/rest/AccessMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/AccessMgrImpl.java
@@ -108,7 +108,7 @@ class AccessMgrImpl extends AbstractMgrImpl
         {
             AccessMgr accessMgr = AccessMgrFactory.createInstance( request.getContextId() );
             Group inGroup = (Group) request.getEntity();
-            Session outSession = accessMgr.createGroupSession( inGroup );
+            Session outSession = accessMgr.createSession( inGroup );
             response.setSession( outSession );
         }
         catch ( SecurityException se )

--- a/src/main/java/org/apache/directory/fortress/rest/AdminMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/AdminMgrImpl.java
@@ -19,24 +19,9 @@
  */
 package org.apache.directory.fortress.rest;
 
-import org.apache.directory.fortress.core.AdminMgr;
-import org.apache.directory.fortress.core.AdminMgrFactory;
-import org.apache.directory.fortress.core.DelAdminMgr;
-import org.apache.directory.fortress.core.DelAdminMgrFactory;
-import org.apache.directory.fortress.core.ReviewMgr;
-import org.apache.directory.fortress.core.ReviewMgrFactory;
+import org.apache.directory.fortress.core.*;
 import org.apache.directory.fortress.core.SecurityException;
-import org.apache.directory.fortress.core.model.AdminRole;
-import org.apache.directory.fortress.core.model.PermGrant;
-import org.apache.directory.fortress.core.model.PermObj;
-import org.apache.directory.fortress.core.model.Permission;
-import org.apache.directory.fortress.core.model.Role;
-import org.apache.directory.fortress.core.model.RoleRelationship;
-import org.apache.directory.fortress.core.model.SDSet;
-import org.apache.directory.fortress.core.model.User;
-import org.apache.directory.fortress.core.model.UserRole;
-import org.apache.directory.fortress.core.model.FortRequest;
-import org.apache.directory.fortress.core.model.FortResponse;
+import org.apache.directory.fortress.core.model.*;
 import org.apache.log4j.Logger;
 
 /**
@@ -304,10 +289,21 @@ class AdminMgrImpl extends AbstractMgrImpl
         try
         {
             AdminMgr adminMgr = AdminMgrFactory.createInstance( request.getContextId() );
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
             adminMgr.setAdmin( request.getSession() );
+            groupMgr.setAdmin( request.getSession() );
             UserRole inRole = (UserRole) request.getEntity();
-            adminMgr.assignUser( inRole );
-            response.setEntity( inRole );
+
+            if ( inRole.isGroupRole() )
+            {
+                Group inGroup = new Group( inRole.getUserId(), Group.Type.ROLE);
+                groupMgr.assign( inGroup, inRole.getName() );
+            }
+            else
+            {
+                adminMgr.assignUser(inRole);
+            }
+            response.setEntity(inRole);
         }
         catch ( SecurityException se )
         {
@@ -326,9 +322,20 @@ class AdminMgrImpl extends AbstractMgrImpl
         try
         {
             AdminMgr adminMgr = AdminMgrFactory.createInstance( request.getContextId() );
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
             adminMgr.setAdmin( request.getSession() );
+            groupMgr.setAdmin( request.getSession() );
             UserRole inRole = (UserRole) request.getEntity();
-            adminMgr.deassignUser( inRole );
+
+            if ( inRole.isGroupRole() )
+            {
+                Group inGroup = new Group( inRole.getUserId(), Group.Type.ROLE);
+                groupMgr.deassign( inGroup, inRole.getName() );
+            }
+            else
+            {
+                adminMgr.deassignUser( inRole );
+            }
             response.setEntity( inRole );
         }
         catch ( SecurityException se )

--- a/src/main/java/org/apache/directory/fortress/rest/AdminMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/AdminMgrImpl.java
@@ -279,70 +279,46 @@ class AdminMgrImpl extends AbstractMgrImpl
         
         return response;
     }
-    
-    
+
+
     /* No qualifier */ FortResponse assignUser( FortRequest request )
     {
         FortResponse response = createResponse();
 
-        
         try
         {
             AdminMgr adminMgr = AdminMgrFactory.createInstance( request.getContextId() );
-            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
             adminMgr.setAdmin( request.getSession() );
-            groupMgr.setAdmin( request.getSession() );
             UserRole inRole = (UserRole) request.getEntity();
-
-            if ( inRole.isGroupRole() )
-            {
-                Group inGroup = new Group( inRole.getUserId(), Group.Type.ROLE);
-                groupMgr.assign( inGroup, inRole.getName() );
-            }
-            else
-            {
-                adminMgr.assignUser(inRole);
-            }
-            response.setEntity(inRole);
-        }
-        catch ( SecurityException se )
-        {
-            createError( response, log, se );
-        }
-        
-        return response;
-    }
-
-    
-    /* No qualifier */ FortResponse deassignUser( FortRequest request )
-    {
-        FortResponse response = createResponse();
-
-        
-        try
-        {
-            AdminMgr adminMgr = AdminMgrFactory.createInstance( request.getContextId() );
-            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
-            adminMgr.setAdmin( request.getSession() );
-            groupMgr.setAdmin( request.getSession() );
-            UserRole inRole = (UserRole) request.getEntity();
-
-            if ( inRole.isGroupRole() )
-            {
-                Group inGroup = new Group( inRole.getUserId(), Group.Type.ROLE);
-                groupMgr.deassign( inGroup, inRole.getName() );
-            }
-            else
-            {
-                adminMgr.deassignUser( inRole );
-            }
+            adminMgr.assignUser( inRole );
             response.setEntity( inRole );
         }
         catch ( SecurityException se )
         {
             createError( response, log, se );
         }
-        
+
+        return response;
+    }
+
+
+    /* No qualifier */ FortResponse deassignUser( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            AdminMgr adminMgr = AdminMgrFactory.createInstance( request.getContextId() );
+            adminMgr.setAdmin( request.getSession() );
+            UserRole inRole = (UserRole) request.getEntity();
+            adminMgr.deassignUser( inRole );
+            response.setEntity( inRole );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+
         return response;
     }
 

--- a/src/main/java/org/apache/directory/fortress/rest/FortressService.java
+++ b/src/main/java/org/apache/directory/fortress/rest/FortressService.java
@@ -3780,7 +3780,7 @@ public interface FortressService
      * @throws SecurityException
      *          in the event of data validation failure, security policy violation or DAO error.
      */
-    FortResponse createGroupSessionTrusted( FortRequest request );
+    FortResponse createGroupSession(FortRequest request );
 
     
     /**
@@ -6823,4 +6823,83 @@ public interface FortressService
      * type {@link org.apache.directory.fortress.core.model.UserRole}
      */
     FortResponse assignedGroupRoles( FortRequest request );
+
+    /**
+     * This command assigns a group to a role.
+     * <ul>
+     *   <li> The command is valid if and only if:
+     *   <li> The group is a member of the GROUPS data set
+     *   <li> The role is a member of the ROLES data set
+     *   <li> The group is not already assigned to the role
+     * </ul>
+     * <h3></h3>
+     * <h4>required parameters</h4>
+     * <ul>
+     *   <li>
+     *     {@link FortRequest#entity} - contains a reference to {@link org.apache.directory.fortress.core.model.UserRole}
+     *     object
+     *   </li>
+     * </ul>
+     * <ul style="list-style-type:none">
+     *   <li>
+     *     <ul style="list-style-type:none">
+     *       <li>
+     *         <h5>UserRole required parameters</h5>
+     *         <ul>
+     *           <li>
+     *             {@link org.apache.directory.fortress.core.model.UserRole#name} - contains the name for already existing
+     *             Role to be assigned
+     *           </li>
+     *           <li>{@link org.apache.directory.fortress.core.model.UserRole#userId} - contains the group name for
+     *           existing Group</li>
+     *         </ul>
+     *       </li>
+     *     </ul>
+     *   </li>
+     * </ul>
+     *
+     * @param request contains a reference to {@code FortRequest}
+     * @return reference to {@code FortResponse}
+     */
+    FortResponse assignGroupRole( FortRequest request );
+
+    /**
+     * This command deletes the assignment of the User from the Role entities. The command is
+     * valid if and only if the group is a member of the GROUPS data set, the role is a member of
+     * the ROLES data set, the group is assigned to the role and group have at least one role assigned.
+     * Any sessions that currently have this role activated will not be effected.
+     * Successful completion includes:
+     * Group entity in GROUP data set has role assignment removed.
+     * <h3></h3>
+     * <h4>required parameters</h4>
+     * <ul>
+     *   <li>
+     *     {@link FortRequest#entity} - contains a reference to {@link org.apache.directory.fortress.core.model.UserRole}
+     *     object
+     *   </li>
+     * </ul>
+     * <ul style="list-style-type:none">
+     *   <li>
+     *     <ul style="list-style-type:none">
+     *       <li>
+     *         <h5>UserRole required parameters</h5>
+     *         <ul>
+     *           <li>
+     *             {@link org.apache.directory.fortress.core.model.UserRole#name} - contains the name for already existing
+     *             Role to be deassigned
+     *           </li>
+     *           <li>
+     *             {@link org.apache.directory.fortress.core.model.UserRole#userId} - contains the group name for existing
+     *             Group
+     *           </li>
+     *         </ul>
+     *       </li>
+     *     </ul>
+     *   </li>
+     * </ul>
+     *
+     * @param request contains a reference to {@code FortRequest}
+     * @return reference to {@code FortResponse}
+     */
+    FortResponse deassignGroupRole( FortRequest request );
 }

--- a/src/main/java/org/apache/directory/fortress/rest/FortressServiceImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/FortressServiceImpl.java
@@ -46,6 +46,7 @@ public class FortressServiceImpl implements FortressService
     private final AccessMgrImpl accessMgrImpl = new AccessMgrImpl();
     private final AuditMgrImpl auditMgrImpl = new AuditMgrImpl();
     private final ConfigMgrImpl configMgrImpl = new ConfigMgrImpl();
+    private final GroupMgrImpl groupMgrImpl = new GroupMgrImpl();
 
     // These are the allowed roles for the Fortress Rest services:
     private static final String SUPER_USER = "fortress-rest-super-user";
@@ -1014,6 +1015,19 @@ public class FortressServiceImpl implements FortressService
      * {@inheritDoc}
      */
     @POST
+    @Path("/" + HttpIds.RBAC_CREATE_GROUP_TRUSTED + "/")
+    @RolesAllowed({SUPER_USER, ACCESS_MGR_USER})
+    @Override
+    public FortResponse createGroupSessionTrusted( FortRequest request )
+    {
+        return accessMgrImpl.createGroupSessionTrusted( request );
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
     @Path("/" + HttpIds.RBAC_AUTHZ + "/")
     @RolesAllowed({SUPER_USER, ACCESS_MGR_USER})
     @Override
@@ -1778,5 +1792,85 @@ public class FortressServiceImpl implements FortressService
     public FortResponse readConfig( FortRequest request )
     {
         return configMgrImpl.readConfig( request );
+    }
+
+    /**
+     * ************************************************************************************************************************************
+     * BEGIN GROUPMGR
+     * **************************************************************************************************************************************
+     */
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_READ + "/")
+    @RolesAllowed({SUPER_USER, ADMIN_MGR_USER})
+    @Override
+    public FortResponse readGroup( FortRequest request )
+    {
+        return groupMgrImpl.readGroup( request );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_ADD + "/")
+    @RolesAllowed({SUPER_USER, ADMIN_MGR_USER})
+    @Override
+    public FortResponse addGroup( FortRequest request )
+    {
+        return groupMgrImpl.addGroup( request );
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_DELETE + "/")
+    @RolesAllowed({SUPER_USER, ADMIN_MGR_USER})
+    @Override
+    public FortResponse deleteGroup( FortRequest request )
+    {
+        return groupMgrImpl.deleteGroup( request );
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_UPDATE + "/")
+    @RolesAllowed({SUPER_USER, ADMIN_MGR_USER})
+    @Override
+    public FortResponse updateGroup( FortRequest request )
+    {
+        return groupMgrImpl.updateGroup( request );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_ROLE_ASGNED + "/")
+    @RolesAllowed({SUPER_USER, REVIEW_MGR_USER})
+    @Override
+    public FortResponse assignedGroupRoles( FortRequest request )
+    {
+        return groupMgrImpl.assignedRoles( request );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_ASGNED + "/")
+    @RolesAllowed({SUPER_USER, REVIEW_MGR_USER})
+    @Override
+    public FortResponse assignedGroups( FortRequest request )
+    {
+        return groupMgrImpl.assignedGroups( request );
     }
 }

--- a/src/main/java/org/apache/directory/fortress/rest/FortressServiceImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/FortressServiceImpl.java
@@ -1015,12 +1015,12 @@ public class FortressServiceImpl implements FortressService
      * {@inheritDoc}
      */
     @POST
-    @Path("/" + HttpIds.RBAC_CREATE_GROUP_TRUSTED + "/")
+    @Path("/" + HttpIds.RBAC_CREATE_GROUP_SESSION + "/")
     @RolesAllowed({SUPER_USER, ACCESS_MGR_USER})
     @Override
-    public FortResponse createGroupSessionTrusted( FortRequest request )
+    public FortResponse createGroupSession(FortRequest request )
     {
-        return accessMgrImpl.createGroupSessionTrusted( request );
+        return accessMgrImpl.createGroupSession( request );
     }
 
 
@@ -1872,5 +1872,29 @@ public class FortressServiceImpl implements FortressService
     public FortResponse assignedGroups( FortRequest request )
     {
         return groupMgrImpl.assignedGroups( request );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_ROLE_ASGN + "/")
+    @RolesAllowed({SUPER_USER, REVIEW_MGR_USER})
+    @Override
+    public FortResponse assignGroupRole(FortRequest request)
+    {
+        return groupMgrImpl.assignGroupRole( request );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @POST
+    @Path("/" + HttpIds.GROUP_ROLE_DEASGN + "/")
+    @RolesAllowed({SUPER_USER, REVIEW_MGR_USER})
+    @Override
+    public FortResponse deassignGroupRole(FortRequest request)
+    {
+        return groupMgrImpl.deassignGroupRole( request );
     }
 }

--- a/src/main/java/org/apache/directory/fortress/rest/GroupMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/GroupMgrImpl.java
@@ -179,5 +179,45 @@ class GroupMgrImpl extends AbstractMgrImpl
         return response;
     }
 
+    /* No qualifier */  FortResponse assignGroupRole( FortRequest request )
+    {
+        FortResponse response = createResponse();
 
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            UserRole inRole = (UserRole) request.getEntity();
+
+            Group inGroup = new Group( inRole.getUserId(), Group.Type.ROLE );
+            groupMgr.assign( inGroup, inRole.getName() );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+
+        return response;
+    }
+
+    /* No qualifier */  FortResponse deassignGroupRole( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            UserRole inRole = (UserRole) request.getEntity();
+
+            Group inGroup = new Group( inRole.getUserId(), Group.Type.ROLE);
+            groupMgr.deassign( inGroup, inRole.getName() );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+
+        return response;
+    }
 }

--- a/src/main/java/org/apache/directory/fortress/rest/GroupMgrImpl.java
+++ b/src/main/java/org/apache/directory/fortress/rest/GroupMgrImpl.java
@@ -1,0 +1,183 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+package org.apache.directory.fortress.rest;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.directory.fortress.core.*;
+import org.apache.directory.fortress.core.SecurityException;
+import org.apache.directory.fortress.core.model.*;
+import org.apache.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility for Fortress Rest Server.  This class is thread safe.
+ *
+ * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
+ */
+class GroupMgrImpl extends AbstractMgrImpl
+{
+    /** A logger for this class */
+    private static final Logger log = Logger.getLogger( GroupMgrImpl.class.getName() );
+
+    
+    /* No qualifier */ FortResponse addGroup( FortRequest request )
+    {
+        FortResponse response = createResponse();
+        
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            Group inGroup = (Group) request.getEntity();
+            Group outGroup = groupMgr.add( inGroup );
+            response.setEntity( outGroup );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+        
+        return response;
+    }
+
+    /* No qualifier */  FortResponse readGroup( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            Group inGroup = (Group) request.getEntity();
+            Group outGroup = groupMgr.read( inGroup );
+            response.setEntity( outGroup );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+
+        return response;
+    }
+
+    
+    /* No qualifier */ FortResponse deleteGroup( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            Group inGroup = (Group) request.getEntity();
+            Group outGroup = groupMgr.read( inGroup );
+            groupMgr.delete( inGroup );
+            response.setEntity( outGroup );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+        
+        return response;
+    }
+
+    
+    /* No qualifier */ FortResponse updateGroup( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            Group inGroup = (Group) request.getEntity();
+            Group outGroup = groupMgr.update( inGroup );
+            response.setEntity( outGroup );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+        
+        return response;
+    }
+
+    /* No qualifier */  FortResponse assignedGroups( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+            Role inRole = (Role) request.getEntity();
+
+            List<Group> groups = groupMgr.roleGroups( inRole );
+            response.setEntities( groups );
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+
+        return response;
+    }
+
+
+    /* No qualifier */  FortResponse assignedRoles( FortRequest request )
+    {
+        FortResponse response = createResponse();
+
+        try
+        {
+            GroupMgr groupMgr = GroupMgrFactory.createInstance( request.getContextId() );
+            groupMgr.setAdmin( request.getSession() );
+
+            if ( StringUtils.isNotEmpty( request.getValue() ) )
+            {
+                String groupName = request.getValue();
+                Group outGroup = groupMgr.read( new Group(groupName) );
+                List<String> retRoles = new ArrayList<>();
+                if ( Group.Type.ROLE.equals( outGroup.getType() ) )
+                {
+                    retRoles = outGroup.getMembers();
+                }
+                response.setValues( retRoles );
+            }
+            else
+            {
+                Group inGroup = (Group) request.getEntity();
+                List<UserRole> uRoles = groupMgr.groupRoles( inGroup );
+                response.setEntities( uRoles );
+            }
+        }
+        catch ( SecurityException se )
+        {
+            createError( response, log, se );
+        }
+
+        return response;
+    }
+
+
+}

--- a/src/test/java/org/apache/directory/fortress/rest/EmTest.java
+++ b/src/test/java/org/apache/directory/fortress/rest/EmTest.java
@@ -73,15 +73,15 @@ public final class EmTest
             testFunction("addPermGrant1.xml", HttpIds.ROLE_REVOKE, false);
             testFunction("delEmGroup1.xml", HttpIds.GROUP_DELETE, false);
             testFunction("addEmTestPermission.xml", HttpIds.PERM_DELETE, false);
-                    testFunction("addEmTestObj1.xml", HttpIds.OBJ_DELETE, false);
+            testFunction("addEmTestObj1.xml", HttpIds.OBJ_DELETE, false);
             testFunction("emTestPermOrg1.xml", HttpIds.ORG_DELETE, false);
             testFunction("emTestPermOrg1.xml", HttpIds.ORG_ADD, true);
-                    testFunction("assignEmUser1.xml", HttpIds.ROLE_DEASGN, false);
+            testFunction("assignEmUser1.xml", HttpIds.ROLE_DEASGN, false);
             testFunction("delEmUser1.xml", HttpIds.USER_DELETE, false);
             testFunction("emTestOrg1.xml", HttpIds.ORG_DELETE, false);
 
             testFunction("emTestOrg1.xml", HttpIds.ORG_ADD, true);
-                    testFunction("emRoleDelInheritance.xml", HttpIds.ROLE_DELINHERIT, false);
+            testFunction("emRoleDelInheritance.xml", HttpIds.ROLE_DELINHERIT, false);
             testFunction("addEmRole1.xml", HttpIds.ROLE_DELETE, false);
             testFunction("delEmRole2.xml", HttpIds.ROLE_DELETE, false);
             testFunction("addEmRole3.xml", HttpIds.ROLE_DELETE, false);
@@ -106,10 +106,10 @@ public final class EmTest
             testFunction("groupRead.xml", HttpIds.GROUP_READ, true);
 
             // Assign 'emrole3' role for group to check api
-            testFunction("assignEmGroup1.xml", HttpIds.ROLE_ASGN, true);
+            testFunction("assignEmGroup1.xml", HttpIds.GROUP_ROLE_ASGN, true);
 
             // Deassign existing 'emrole3' from group
-            testFunction("assignEmGroup1.xml", HttpIds.ROLE_DEASGN, true);
+            testFunction("assignEmGroup1.xml", HttpIds.GROUP_ROLE_DEASGN, true);
 
             // Read group roles
             testFunction("groupRead.xml", HttpIds.GROUP_ROLE_ASGNED, true);
@@ -118,7 +118,7 @@ public final class EmTest
             testFunction("addEmRole1.xml", HttpIds.GROUP_ASGNED, true);
 
             // Create trusted group-based session
-            testFunction("createGroupSession.xml", HttpIds.RBAC_CREATE_GROUP_TRUSTED, true);
+            testFunction("createGroupSession.xml", HttpIds.RBAC_CREATE_GROUP_SESSION, true);
 
             // Use this group session to check access (URL is the same as for user, but session has 'isGroupSession' == true)
             testFunction("emTestCheckAccessGroupSession.xml", HttpIds.RBAC_AUTHZ, true);
@@ -146,7 +146,7 @@ public final class EmTest
         FortResponse response = RestUtils.unmarshall(szResponse);
         int rc = response.getErrorCode();
         String szErrorMsg = response.getErrorMessage();
-        String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_REVOKE + " rc=" + rc + " error message=" + szErrorMsg;
+        String warn = CLS_NM + ".testServices FAILED calling " + function + " rc=" + rc + " error message=" + szErrorMsg;
         if(rc != 0)
         {
             log.info(warn);

--- a/src/test/java/org/apache/directory/fortress/rest/EmTest.java
+++ b/src/test/java/org/apache/directory/fortress/rest/EmTest.java
@@ -53,10 +53,8 @@ public final class EmTest
     private static final Logger log = Logger.getLogger(CLS_NM);
     private static final String HOST = "localhost";
     private static final String PORT = "8080";
-//    private static final String VERSION = System.getProperty("version");
-    private static final String VERSION = "1.0.2-SNAPSHOT-G";
-    private static final String SERVICE = "fortress-rest-" + VERSION;
-    //private static final String SERVICE = "enmasse-" + VERSION;
+    private static final String VERSION = System.getProperty("version");
+    private static final String SERVICE = "enmasse-" + VERSION;
     private static final String URI = "http://" + HOST + ":" + PORT + "/" + SERVICE + "/";
     private static final String USER_ID = "demouser4";
     private static final String PASSWORD = "password";

--- a/src/test/java/org/apache/directory/fortress/rest/EmTest.java
+++ b/src/test/java/org/apache/directory/fortress/rest/EmTest.java
@@ -36,6 +36,7 @@ import org.apache.commons.httpclient.methods.*;
 import org.apache.cxf.common.util.Base64Utility;
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
@@ -52,7 +53,8 @@ public final class EmTest
     private static final Logger log = Logger.getLogger(CLS_NM);
     private static final String HOST = "localhost";
     private static final String PORT = "8080";
-    private static final String VERSION = System.getProperty("version");
+//    private static final String VERSION = System.getProperty("version");
+    private static final String VERSION = "1.0.2-SNAPSHOT-G";
     private static final String SERVICE = "fortress-rest-" + VERSION;
     //private static final String SERVICE = "enmasse-" + VERSION;
     private static final String URI = "http://" + HOST + ":" + PORT + "/" + SERVICE + "/";
@@ -69,247 +71,59 @@ public final class EmTest
         log.info(CLS_NM + ".testServices STARTED");
         try
         {
-            String szResponse = post(USER_ID, PASSWORD, "addPermGrant1.xml", HttpIds.ROLE_REVOKE);
-            FortResponse response = RestUtils.unmarshall(szResponse);
-            int rc = response.getErrorCode();
-            String szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_REVOKE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Don't fail if the delete was not successful as this may be the first run:
+            testFunction("addPermGrant1.xml", HttpIds.ROLE_REVOKE, false);
+            testFunction("delEmGroup1.xml", HttpIds.GROUP_DELETE, false);
+            testFunction("addEmTestPermission.xml", HttpIds.PERM_DELETE, false);
+                    testFunction("addEmTestObj1.xml", HttpIds.OBJ_DELETE, false);
+            testFunction("emTestPermOrg1.xml", HttpIds.ORG_DELETE, false);
+            testFunction("emTestPermOrg1.xml", HttpIds.ORG_ADD, true);
+                    testFunction("assignEmUser1.xml", HttpIds.ROLE_DEASGN, false);
+            testFunction("delEmUser1.xml", HttpIds.USER_DELETE, false);
+            testFunction("emTestOrg1.xml", HttpIds.ORG_DELETE, false);
 
-            szResponse = post(USER_ID, PASSWORD, "addEmTestPermission.xml", HttpIds.PERM_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.PERM_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            testFunction("emTestOrg1.xml", HttpIds.ORG_ADD, true);
+                    testFunction("emRoleDelInheritance.xml", HttpIds.ROLE_DELINHERIT, false);
+            testFunction("addEmRole1.xml", HttpIds.ROLE_DELETE, false);
+            testFunction("delEmRole2.xml", HttpIds.ROLE_DELETE, false);
+            testFunction("addEmRole3.xml", HttpIds.ROLE_DELETE, false);
 
-            szResponse = post(USER_ID, PASSWORD, "addEmTestObj1.xml", HttpIds.OBJ_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.OBJ_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Create objects and start testing
+            testFunction("addEmRole1.xml", HttpIds.ROLE_ADD, true);
+            testFunction("addEmRole3.xml", HttpIds.ROLE_ADD, true);
+            testFunction("addEmRole2Ascendent.xml", HttpIds.ROLE_ASC, true);
+            testFunction("addEmUser1.xml", HttpIds.USER_ADD, true);
+            testFunction("assignEmUser1.xml", HttpIds.ROLE_ASGN, true);
+            testFunction("emTestAuthN.xml", HttpIds.RBAC_AUTHN, true);
+            testFunction("createSession.xml", HttpIds.RBAC_CREATE, true);
+            testFunction("addEmTestObj1.xml", HttpIds.OBJ_ADD, true);
+            testFunction("addEmTestPermission.xml", HttpIds.PERM_ADD, true);
+            testFunction("addPermGrant1.xml", HttpIds.ROLE_GRANT, true);
+            testFunction("emTestCheckAccess.xml", HttpIds.RBAC_AUTHZ, true);
 
-            szResponse = post(USER_ID, PASSWORD, "emTestPermOrg1.xml", HttpIds.ORG_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ORG_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Create 'emtestgroup1' group with type 'ROLE' and role 'emrole1'
+            testFunction("addEmGroup1.xml", HttpIds.GROUP_ADD, true);
 
-            szResponse = post(USER_ID, PASSWORD, "emTestPermOrg1.xml", HttpIds.ORG_ADD);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.ORG_ADD + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
+            // Read 'emtestgroup1' group by its name
+            testFunction("groupRead.xml", HttpIds.GROUP_READ, true);
 
-            szResponse = post(USER_ID, PASSWORD, "assignEmUser1.xml", HttpIds.ROLE_DEASGN);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_DEASGN + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Assign 'emrole3' role for group to check api
+            testFunction("assignEmGroup1.xml", HttpIds.ROLE_ASGN, true);
 
-            szResponse = post(USER_ID, PASSWORD, "delEmUser1.xml", HttpIds.USER_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.USER_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Deassign existing 'emrole3' from group
+            testFunction("assignEmGroup1.xml", HttpIds.ROLE_DEASGN, true);
 
-            szResponse = post(USER_ID, PASSWORD, "emTestOrg1.xml", HttpIds.ORG_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ORG_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Read group roles
+            testFunction("groupRead.xml", HttpIds.GROUP_ROLE_ASGNED, true);
 
-            szResponse = post(USER_ID, PASSWORD, "emTestOrg1.xml", HttpIds.ORG_ADD);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.ORG_ADD + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
+            // Read groups assigned to 'emrole1' role
+            testFunction("addEmRole1.xml", HttpIds.GROUP_ASGNED, true);
 
-            szResponse = post(USER_ID, PASSWORD, "emRoleDelInheritance.xml", HttpIds.ROLE_DELINHERIT);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_DELINHERIT + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
+            // Create trusted group-based session
+            testFunction("createGroupSession.xml", HttpIds.RBAC_CREATE_GROUP_TRUSTED, true);
 
-            szResponse = post(USER_ID, PASSWORD, "addEmRole1.xml", HttpIds.ROLE_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
-
-            szResponse = post(USER_ID, PASSWORD, "delEmRole2.xml", HttpIds.ROLE_DELETE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                // don't fail if the delete was not successful as this may be the first run:
-                String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_DELETE + " rc=" + rc + " error message=" + szErrorMsg;
-                log.info(warn);
-            }
-
-            szResponse = post(USER_ID, PASSWORD, "addEmRole1.xml", HttpIds.ROLE_ADD);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_ADD + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "addEmRole2Ascendent.xml", HttpIds.ROLE_ASC);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_ASC + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "addEmUser1.xml", HttpIds.USER_ADD);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.USER_ADD + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "assignEmUser1.xml", HttpIds.ROLE_ASGN);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_ASGN + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "emTestAuthN.xml", HttpIds.RBAC_AUTHN);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.RBAC_AUTHN + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "createSession.xml", HttpIds.RBAC_CREATE);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.RBAC_AUTHN + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "addEmTestObj1.xml", HttpIds.OBJ_ADD);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.OBJ_ADD + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "addEmTestPermission.xml", HttpIds.PERM_ADD);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.PERM_ADD + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "addPermGrant1.xml", HttpIds.ROLE_GRANT);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_GRANT + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
-
-            szResponse = post(USER_ID, PASSWORD, "emTestCheckAccess.xml", HttpIds.RBAC_AUTHZ);
-            response = RestUtils.unmarshall(szResponse);
-            rc = response.getErrorCode();
-            szErrorMsg = response.getErrorMessage();
-            if(rc != 0)
-            {
-                String error = CLS_NM + ".testServices failed calling " + HttpIds.RBAC_AUTHZ + " rc=" + rc + " error message=" + szErrorMsg;
-                log.error(error);
-            }
-            assert(rc == 0);
+            // Use this group session to check access (URL is the same as for user, but session has 'isGroupSession' == true)
+            testFunction("emTestCheckAccessGroupSession.xml", HttpIds.RBAC_AUTHZ, true);
 
             log.info(CLS_NM + ".testServices SUCCESS");
         }
@@ -322,6 +136,30 @@ public final class EmTest
     }
 
     /**
+     * Performs a request to a given function URL with given filename.
+     * @param xmlFile         name of the file (to be searched in resources)
+     * @param function url of the REST API function
+     * @param failOnError if 'true', will fail on error in API request
+     * @throws RestException
+     */
+    public void testFunction(String xmlFile, String function, boolean failOnError) throws RestException
+    {
+        String szResponse = post(USER_ID, PASSWORD, xmlFile, function);
+        FortResponse response = RestUtils.unmarshall(szResponse);
+        int rc = response.getErrorCode();
+        String szErrorMsg = response.getErrorMessage();
+        String warn = CLS_NM + ".testServices FAILED calling " + HttpIds.ROLE_REVOKE + " rc=" + rc + " error message=" + szErrorMsg;
+        if(rc != 0)
+        {
+            log.info(warn);
+        }
+        if (failOnError)
+        {
+            Assert.assertEquals(warn, 0, rc);
+        }
+    }
+
+    /**
      * Perform an HTTP Post to the configured server.
      *
      * @param userId
@@ -330,7 +168,7 @@ public final class EmTest
      * @param function
      * @throws RestException
      */
-    private String post(String userId, String password, String xmlFile, String function) throws RestException
+    public String post(String userId, String password, String xmlFile, String function) throws RestException
     {
         String szResponse;
         log.info(CLS_NM + ".post file:" + xmlFile + " HTTP POST request to:" + function);

--- a/src/test/resources/addEmGroup1.xml
+++ b/src/test/resources/addEmGroup1.xml
@@ -19,17 +19,12 @@
 -->
 
 <FortRequest>
-      <contextId>HOME</contextId>
-      <entity xsi:type="role" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-         <name>emrole1</name>
-         <description>em test role 1</description>
-          <beginDate>20120101</beginDate>
-          <endLockDate>20130101</endLockDate>
-          <beginTime>0800</beginTime>
-          <endTime>2300</endTime>
-          <dayMask>23456</dayMask>
-          <beginLockDate>none</beginLockDate>
-          <endDate>none</endDate>
-         <timeout>0</timeout>
-      </entity>
-   </FortRequest>
+   <contextId>HOME</contextId>
+   <entity xsi:type="group" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <name>emtestgroup1</name>
+      <description>enmasse testgroup1</description>
+      <protocol>protocol</protocol>
+      <type>ROLE</type>
+      <members>emrole1</members>
+   </entity>
+</FortRequest>

--- a/src/test/resources/addEmRole3.xml
+++ b/src/test/resources/addEmRole3.xml
@@ -21,13 +21,13 @@
 <FortRequest>
       <contextId>HOME</contextId>
       <entity xsi:type="role" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-         <name>emrole1</name>
-         <description>em test role 1</description>
+         <name>emrole3</name>
+         <description>em test role 3</description>
           <beginDate>20120101</beginDate>
           <endLockDate>20130101</endLockDate>
           <beginTime>0800</beginTime>
           <endTime>2300</endTime>
-          <dayMask>23456</dayMask>
+          <dayMask>1234567</dayMask>
           <beginLockDate>none</beginLockDate>
           <endDate>none</endDate>
          <timeout>0</timeout>

--- a/src/test/resources/assignEmGroup1.xml
+++ b/src/test/resources/assignEmGroup1.xml
@@ -20,16 +20,16 @@
 
 <FortRequest>
       <contextId>HOME</contextId>
-      <entity xsi:type="role" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-         <name>emrole1</name>
-         <description>em test role 1</description>
-          <beginDate>20120101</beginDate>
-          <endLockDate>20130101</endLockDate>
-          <beginTime>0800</beginTime>
-          <endTime>2300</endTime>
-          <dayMask>23456</dayMask>
-          <beginLockDate>none</beginLockDate>
-          <endDate>none</endDate>
-         <timeout>0</timeout>
+      <entity xsi:type="userRole" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+         <userId>emtestgroup1</userId>
+         <name>emrole3</name>
+         <isGroupRole>true</isGroupRole>   <!-- Note this flag-->
+         <beginDate>20120101</beginDate>
+         <endLockDate>20140101</endLockDate>
+         <beginTime>0100</beginTime>
+         <endTime>2359</endTime>
+         <dayMask>1234567</dayMask>
+         <beginLockDate>none</beginLockDate>
+         <endDate>none</endDate>
       </entity>
    </FortRequest>

--- a/src/test/resources/createGroupSession.xml
+++ b/src/test/resources/createGroupSession.xml
@@ -19,17 +19,8 @@
 -->
 
 <FortRequest>
-      <contextId>HOME</contextId>
-      <entity xsi:type="role" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-         <name>emrole1</name>
-         <description>em test role 1</description>
-          <beginDate>20120101</beginDate>
-          <endLockDate>20130101</endLockDate>
-          <beginTime>0800</beginTime>
-          <endTime>2300</endTime>
-          <dayMask>23456</dayMask>
-          <beginLockDate>none</beginLockDate>
-          <endDate>none</endDate>
-         <timeout>0</timeout>
-      </entity>
-   </FortRequest>
+    <contextId>HOME</contextId>
+    <entity xsi:type="group" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <name>emtestgroup1</name>
+    </entity>
+</FortRequest>

--- a/src/test/resources/delEmGroup1.xml
+++ b/src/test/resources/delEmGroup1.xml
@@ -19,17 +19,8 @@
 -->
 
 <FortRequest>
-      <contextId>HOME</contextId>
-      <entity xsi:type="role" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-         <name>emrole1</name>
-         <description>em test role 1</description>
-          <beginDate>20120101</beginDate>
-          <endLockDate>20130101</endLockDate>
-          <beginTime>0800</beginTime>
-          <endTime>2300</endTime>
-          <dayMask>23456</dayMask>
-          <beginLockDate>none</beginLockDate>
-          <endDate>none</endDate>
-         <timeout>0</timeout>
-      </entity>
-   </FortRequest>
+    <contextId>HOME</contextId>
+    <entity xsi:type="group" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <name>emtestgroup1</name>
+    </entity>
+</FortRequest>

--- a/src/test/resources/emTestCheckAccessGroupSession.xml
+++ b/src/test/resources/emTestCheckAccessGroupSession.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+
+<FortRequest>
+    <contextId>HOME</contextId>
+    <entity xsi:type="permission" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <objName>emtestobj1</objName>
+        <opName>add</opName>
+        <admin>false</admin>
+    </entity>
+    <session>
+        <modId>90d56d72-9682-42c7-88b5-ab6b6de08077</modId>
+        <group>
+            <modId>c8df7f86-a2a2-4936-9c4c-9a707dd271e2</modId>
+            <name>emtestgroup1</name>
+            <description>enmasse testgroup1</description>
+            <members>cn=emrole1,ou=Roles,ou=RBAC,dc=example,dc=com</members>
+            <props>
+                <modId>1cea1518-71b1-42cd-87c8-5deb2fc35866</modId>
+            </props>
+            <type>ROLE</type>
+            <roles>
+                <modId>743bfe08-cde6-470a-ab88-334e176185f4</modId>
+                <name>emrole1</name>
+                <userId>emtestgroup1</userId>
+                <isGroupRole>true</isGroupRole>
+                <beginDate>20120101</beginDate>
+                <beginLockDate>none</beginLockDate>
+                <beginTime>0800</beginTime>
+                <dayMask>23456</dayMask>
+                <endDate>none</endDate>
+                <endLockDate>20130101</endLockDate>
+                <endTime>2300</endTime>
+                <timeout>0</timeout>
+            </roles>
+        </group>
+        <isAuthenticated>false</isAuthenticated>
+        <isGroupSession>true</isGroupSession>
+        <sessionId>07638412-071d-4977-a3d0-c8b92ff81784</sessionId>
+        <lastAccess>1473354158807</lastAccess>
+        <timeout>0</timeout>
+        <errorId>0</errorId>
+        <expirationSeconds>0</expirationSeconds>
+        <graceLogins>0</graceLogins>
+    </session>
+</FortRequest>

--- a/src/test/resources/groupRead.xml
+++ b/src/test/resources/groupRead.xml
@@ -19,17 +19,8 @@
 -->
 
 <FortRequest>
-      <contextId>HOME</contextId>
-      <entity xsi:type="role" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-         <name>emrole1</name>
-         <description>em test role 1</description>
-          <beginDate>20120101</beginDate>
-          <endLockDate>20130101</endLockDate>
-          <beginTime>0800</beginTime>
-          <endTime>2300</endTime>
-          <dayMask>23456</dayMask>
-          <beginLockDate>none</beginLockDate>
-          <endDate>none</endDate>
-         <timeout>0</timeout>
-      </entity>
-   </FortRequest>
+    <contextId>HOME</contextId>
+    <entity xsi:type="group" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <name>emtestgroup1</name>
+    </entity>
+</FortRequest>


### PR DESCRIPTION
 There're certain situations where userId is not known to the tenant.
  Possible use case here is federated and multi-tenant login into
  openstack via keystone.  This commit propagates changes from
  Fortress Core project to achieve this and adds new API methods.

Resolves FC-144(https://issues.apache.org/jira/browse/FC-144)